### PR TITLE
Bank Account Entries from Their Own Table

### DIFF
--- a/app/Entities/Invoices/BankAccount.php
+++ b/app/Entities/Invoices/BankAccount.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Entities\Invoices;
+
+use Illuminate\Database\Eloquent\Model;
+
+class BankAccount extends Model
+{
+    protected $fillable = ['name', 'number', 'account_name', 'description'];
+}

--- a/app/Http/Controllers/References/BankAccountsController.php
+++ b/app/Http/Controllers/References/BankAccountsController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\References;
 use Illuminate\Http\Request;
 use App\Entities\Options\Option;
 use App\Http\Controllers\Controller;
+use App\Entities\Invoices\BankAccount;
 
 /**
  * Bank Account Controller.
@@ -21,21 +22,10 @@ class BankAccountsController extends Controller
     public function index()
     {
         $editableBankAccount = null;
-        $bankAccounts = Option::where('key', 'bank_accounts')->first();
+        $bankAccounts = BankAccount::all();
 
-        if (!is_null($bankAccounts)) {
-            $bankAccounts = $bankAccounts->value;
-            $bankAccounts = json_decode($bankAccounts, true);
-            $bankAccounts = collect($bankAccounts)
-                ->map(function ($bankAccount) {
-                    return (object) $bankAccount;
-                });
-
-            if (in_array(request('action'), ['edit', 'delete']) && request('id') != null) {
-                $editableBankAccount = $bankAccounts[request('id')];
-            }
-        } else {
-            $bankAccounts = collect([]);
+        if (in_array(request('action'), ['edit', 'delete']) && request('id') != null) {
+            $editableBankAccount = BankAccount::find(request('id'));
         }
 
         return view('bank-accounts.index', compact('bankAccounts', 'editableBankAccount'));

--- a/app/Http/Controllers/References/BankAccountsController.php
+++ b/app/Http/Controllers/References/BankAccountsController.php
@@ -14,9 +14,9 @@ use App\Entities\Invoices\BankAccount;
 class BankAccountsController extends Controller
 {
     /**
-     * Display a listing of the bankAccount.
+     * Display a listing of the bank account.
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\View\View
      */
     public function index()
     {
@@ -33,9 +33,8 @@ class BankAccountsController extends Controller
     /**
      * Store a newly created bank account in storage.
      *
-     * @param \Illuminate\Http\Request $request
-     *
-     * @return \Illuminate\Http\Response
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function store(Request $request)
     {
@@ -56,10 +55,9 @@ class BankAccountsController extends Controller
     /**
      * Update the specified bank account in storage.
      *
-     * @param \Illuminate\Http\Request           $request
-     * @param \App\Entities\Invoices\BankAccount $bankAccount
-     *
-     * @return \Illuminate\Http\Response
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \App\Entities\Invoices\BankAccount  $bankAccount
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function update(Request $request, BankAccount $bankAccount)
     {
@@ -80,9 +78,8 @@ class BankAccountsController extends Controller
     /**
      * Remove the specified bank account from storage.
      *
-     * @param \App\Entities\Invoices\BankAccount $bankAccount
-     *
-     * @return \Illuminate\Http\Response
+     * @param  \App\Entities\Invoices\BankAccount  $bankAccount
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function destroy(BankAccount $bankAccount)
     {
@@ -91,7 +88,6 @@ class BankAccountsController extends Controller
         ]);
 
         if (request('bank_account_id') == $bankAccount->id && $bankAccount->delete()) {
-
             flash(trans('bank_account.deleted'), 'success');
 
             return redirect()->route('bank-accounts.index');

--- a/app/Http/Controllers/References/BankAccountsController.php
+++ b/app/Http/Controllers/References/BankAccountsController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\References;
 
 use Illuminate\Http\Request;
-use App\Entities\Options\Option;
 use App\Http\Controllers\Controller;
 use App\Entities\Invoices\BankAccount;
 
@@ -47,24 +46,7 @@ class BankAccountsController extends Controller
             'description'  => 'nullable|max:255',
         ]);
 
-        $option = Option::firstOrNew(['key' => 'bank_accounts']);
-        if ($option->exists) {
-            $bankAccounts = $option->value;
-            $bankAccounts = json_decode($bankAccounts, true);
-            if ($bankAccounts == []) {
-                $bankAccounts[1] = $newBankAccount;
-            } else {
-                $bankAccounts[] = $newBankAccount;
-            }
-        } else {
-            $bankAccounts = [];
-            $bankAccounts[1] = $newBankAccount;
-        }
-
-        $bankAccounts = json_encode($bankAccounts);
-
-        $option->value = $bankAccounts;
-        $option->save();
+        BankAccount::create($newBankAccount);
 
         flash(trans('bank_account.created'), 'success');
 
@@ -79,7 +61,7 @@ class BankAccountsController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, $bankAccountId)
+    public function update(Request $request, BankAccount $bankAccount)
     {
         $bankAccountData = $request->validate([
             'name'         => 'required|max:60',
@@ -88,18 +70,7 @@ class BankAccountsController extends Controller
             'description'  => 'nullable|max:255',
         ]);
 
-        $bankAccounts = Option::where('key', 'bank_accounts')->first();
-
-        $bankAccounts = $bankAccounts->value;
-        $bankAccounts = json_decode($bankAccounts, true);
-
-        $bankAccounts[$bankAccountId] = $bankAccountData;
-
-        $bankAccounts = json_encode($bankAccounts);
-
-        $option = Option::where('key', 'bank_accounts')->first();
-        $option->value = $bankAccounts;
-        $option->save();
+        $bankAccount->update($bankAccountData);
 
         flash(trans('bank_account.updated'), 'success');
 
@@ -113,25 +84,13 @@ class BankAccountsController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function destroy($bankAccountId)
+    public function destroy(BankAccount $bankAccount)
     {
         request()->validate([
             'bank_account_id' => 'required',
         ]);
 
-        if (request('bank_account_id') == $bankAccountId) {
-            $bankAccounts = Option::where('key', 'bank_accounts')->first();
-
-            $bankAccounts = $bankAccounts->value;
-            $bankAccounts = json_decode($bankAccounts, true);
-
-            unset($bankAccounts[$bankAccountId]);
-
-            $bankAccounts = json_encode($bankAccounts);
-
-            $option = Option::where('key', 'bank_accounts')->first();
-            $option->value = $bankAccounts;
-            $option->save();
+        if (request('bank_account_id') == $bankAccount->id && $bankAccount->delete()) {
 
             flash(trans('bank_account.deleted'), 'success');
 

--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
     "content-hash": "fd28a38cbcaf3bccc1d6fb34444372ee",
@@ -3008,16 +3008,16 @@
         },
         {
             "name": "luthfi/simple-crud-generator",
-            "version": "1.2.3",
+            "version": "1.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nafiesl/SimpleCrudGenerator.git",
-                "reference": "6a64e62c3b91eb92739b7c7b89d2e3439d180c94"
+                "reference": "0dc629fab1c1708eedf545aa81c428905e7e4864"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nafiesl/SimpleCrudGenerator/zipball/6a64e62c3b91eb92739b7c7b89d2e3439d180c94",
-                "reference": "6a64e62c3b91eb92739b7c7b89d2e3439d180c94",
+                "url": "https://api.github.com/repos/nafiesl/SimpleCrudGenerator/zipball/0dc629fab1c1708eedf545aa81c428905e7e4864",
+                "reference": "0dc629fab1c1708eedf545aa81c428905e7e4864",
                 "shasum": ""
             },
             "require": {
@@ -3060,7 +3060,7 @@
                 "tdd-workflow",
                 "testing"
             ],
-            "time": "2018-09-10T09:02:29+00:00"
+            "time": "2018-10-23T09:49:27+00:00"
         },
         {
             "name": "maximebf/debugbar",

--- a/database/factories/BankAccountFactory.php
+++ b/database/factories/BankAccountFactory.php
@@ -1,0 +1,12 @@
+<?php
+
+use Faker\Generator as Faker;
+use App\Entities\Invoices\BankAccount;
+
+$factory->define(BankAccount::class, function (Faker $faker) {
+    return [
+        'name'         => 'Bank '.strtoupper(str_random(4)),
+        'number'       => str_random(10),
+        'account_name' => $faker->name,
+    ];
+});

--- a/database/migrations/2018_10_30_215937_create_bank_accounts_table.php
+++ b/database/migrations/2018_10_30_215937_create_bank_accounts_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateBankAccountsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('bank_accounts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name', 60);
+            $table->string('number', 30);
+            $table->string('account_name', 60);
+            $table->string('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('bank_accounts');
+    }
+}

--- a/resources/views/bank-accounts/index.blade.php
+++ b/resources/views/bank-accounts/index.blade.php
@@ -6,7 +6,7 @@
 
 <div class="row">
     <div class="col-md-8">
-        @foreach ($bankAccounts as $key => $bankAccount)
+        @foreach ($bankAccounts as $bankAccount)
             <div class="col-md-6">
                 <div class="panel panel-default">
                     <div class="panel-heading text-center"><h3 class="panel-title">{{ $bankAccount->name }}</h3></div>
@@ -21,14 +21,14 @@
                         {!! link_to_route(
                             'bank-accounts.index',
                             trans('app.edit'),
-                            ['action' => 'edit', 'id' => $key],
-                            ['id' => 'edit-bank_account-' . $key]
+                            ['action' => 'edit', 'id' => $bankAccount->id],
+                            ['id' => 'edit-bank_account-' . $bankAccount->id]
                         ) !!}
                         {!! link_to_route(
                             'bank-accounts.index',
                             trans('app.delete'),
-                            ['action' => 'delete', 'id' => $key],
-                            ['id' => 'del-bank_account-' . $key, 'class' => 'pull-right']
+                            ['action' => 'delete', 'id' => $bankAccount->id],
+                            ['id' => 'del-bank_account-' . $bankAccount->id, 'class' => 'pull-right']
                         ) !!}
                     </div>
                 </div>

--- a/tests/Feature/References/ManageBankAccountsTest.php
+++ b/tests/Feature/References/ManageBankAccountsTest.php
@@ -2,8 +2,7 @@
 
 namespace Tests\Feature\References;
 
-use Option;
-use Tests\TestCase as TestCase;
+use Tests\TestCase;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 
 /**
@@ -19,7 +18,10 @@ class ManageBankAccountsTest extends TestCase
     public function user_can_see_bank_account_list_in_bank_account_index_page()
     {
         $this->adminUserSigningIn();
+        $bankAccount = factory(BankAccount::class)->create();
         $this->visit(route('bank-accounts.index'));
+
+        $this->seeText($bankAccount->name);
     }
 
     /** @test */
@@ -28,10 +30,10 @@ class ManageBankAccountsTest extends TestCase
         $this->adminUserSigningIn();
         $this->visit(route('bank-accounts.index'));
 
-        $this->click(trans('bank_account.create'));
+        $this->click(__('bank_account.create'));
         $this->seePageIs(route('bank-accounts.index', ['action' => 'create']));
 
-        $this->submitForm(trans('bank_account.create'), [
+        $this->submitForm(__('bank_account.create'), [
             'name'         => 'BankAccount 1 name',
             'number'       => '1234567890',
             'account_name' => 'John Doe',
@@ -40,40 +42,26 @@ class ManageBankAccountsTest extends TestCase
 
         $this->seePageIs(route('bank-accounts.index'));
 
-        $bankAccounts = [];
-
-        $bankAccounts[1] = [
+        $this->seeInDatabase('bank_accounts', [
             'name'         => 'BankAccount 1 name',
             'number'       => '1234567890',
             'account_name' => 'John Doe',
             'description'  => 'BankAccount 1 description',
-        ];
-
-        $this->seeInDatabase('site_options', [
-            'value' => json_encode($bankAccounts),
         ]);
     }
 
     /** @test */
-    public function user_can_edit_a_bank_account_within_search_query()
+    public function user_can_edit_a_bank_account()
     {
         $this->adminUserSigningIn();
 
-        $bankAccounts = [];
-        $bankAccounts[1] = [
-            'name'         => 'BankAccount 1 name',
-            'number'       => '1234567890',
-            'account_name' => 'John Doe',
-            'description'  => 'BankAccount 1 description',
-        ];
-
-        Option::set('bank_accounts', json_encode($bankAccounts));
+        $bankAccount = factory(BankAccount::class)->create();
 
         $this->visit(route('bank-accounts.index'));
         $this->click('edit-bank_account-1');
-        $this->seePageIs(route('bank-accounts.index', ['action' => 'edit', 'id' => '1']));
+        $this->seePageIs(route('bank-accounts.index', ['action' => 'edit', 'id' => $bankAccount->id]));
 
-        $this->submitForm(trans('bank_account.update'), [
+        $this->submitForm(__('bank_account.update'), [
             'name'         => 'BankAccount 2 name',
             'number'       => '1234567890',
             'account_name' => 'John Doe',
@@ -82,15 +70,11 @@ class ManageBankAccountsTest extends TestCase
 
         $this->seePageIs(route('bank-accounts.index'));
 
-        $bankAccounts[1] = [
+        $this->seeInDatabase('bank_accounts', [
             'name'         => 'BankAccount 2 name',
             'number'       => '1234567890',
             'account_name' => 'John Doe',
             'description'  => 'BankAccount 2 description',
-        ];
-
-        $this->seeInDatabase('site_options', [
-            'value' => json_encode($bankAccounts),
         ]);
     }
 
@@ -99,28 +83,16 @@ class ManageBankAccountsTest extends TestCase
     {
         $this->adminUserSigningIn();
 
-        $bankAccounts = [];
-        $bankAccounts[2] = [
-            'name'         => 'BankAccount 1 name',
-            'number'       => '1234567890',
-            'account_name' => 'John Doe',
-            'description'  => 'BankAccount 1 description',
-        ];
-
-        Option::set('bank_accounts', json_encode($bankAccounts));
-
-        $this->seeInDatabase('site_options', [
-            'value' => json_encode($bankAccounts),
-        ]);
+        $bankAccount = factory(BankAccount::class)->create();
 
         $this->visit(route('bank-accounts.index'));
-        $this->click('del-bank_account-2');
+        $this->click('del-bank_account-'.$bankAccount->id);
         $this->seePageIs(route('bank-accounts.index', ['action' => 'delete', 'id' => '2']));
 
-        $this->press(trans('app.delete_confirm_button'));
+        $this->press(__('app.delete_confirm_button'));
 
-        $this->dontSeeInDatabase('site_options', [
-            'value' => json_encode($bankAccounts),
+        $this->dontSeeInDatabase('bank_accounts', [
+            'id' => $bankAccount->id,
         ]);
     }
 }

--- a/tests/Feature/References/ManageBankAccountsTest.php
+++ b/tests/Feature/References/ManageBankAccountsTest.php
@@ -88,7 +88,7 @@ class ManageBankAccountsTest extends TestCase
 
         $this->visit(route('bank-accounts.index'));
         $this->click('del-bank_account-'.$bankAccount->id);
-        $this->seePageIs(route('bank-accounts.index', ['action' => 'delete', 'id' => '2']));
+        $this->seePageIs(route('bank-accounts.index', ['action' => 'delete', 'id' => $bankAccount->id]));
 
         $this->press(__('app.delete_confirm_button'));
 

--- a/tests/Feature/References/ManageBankAccountsTest.php
+++ b/tests/Feature/References/ManageBankAccountsTest.php
@@ -60,7 +60,10 @@ class ManageBankAccountsTest extends TestCase
 
         $this->visit(route('bank-accounts.index'));
         $this->click('edit-bank_account-1');
-        $this->seePageIs(route('bank-accounts.index', ['action' => 'edit', 'id' => $bankAccount->id]));
+
+        $this->seePageIs(route('bank-accounts.index', [
+            'action' => 'edit', 'id' => $bankAccount->id,
+        ]));
 
         $this->submitForm(__('bank_account.update'), [
             'name'         => 'BankAccount 2 name',
@@ -88,7 +91,10 @@ class ManageBankAccountsTest extends TestCase
 
         $this->visit(route('bank-accounts.index'));
         $this->click('del-bank_account-'.$bankAccount->id);
-        $this->seePageIs(route('bank-accounts.index', ['action' => 'delete', 'id' => $bankAccount->id]));
+
+        $this->seePageIs(route('bank-accounts.index', [
+            'action' => 'delete', 'id' => $bankAccount->id,
+        ]));
 
         $this->press(__('app.delete_confirm_button'));
 

--- a/tests/Feature/References/ManageBankAccountsTest.php
+++ b/tests/Feature/References/ManageBankAccountsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\References;
 
 use Tests\TestCase;
+use App\Entities\Invoices\BankAccount;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 
 /**


### PR DESCRIPTION
Fixing bug on issue #19.

In this PR, we are creating bank account entry on their own `bank_accounts` table with `BankAccount` model.

This PR contains some changes on bank account management feature:
[x] List bank account from `bank_accounts` table.
[x] Create new bank account
[x] Edit bank account entry
[x] Delete bank account entry
[ ] Import bank account button for existing users (import bank account list from `site_options` table).

We will add new `bank_accounts` table via migration. Run `php artisan migrate`.