### PR TITLE
Project deletion will also deletes related records

### DIFF
--- a/app/Entities/Projects/Job.php
+++ b/app/Entities/Projects/Job.php
@@ -2,6 +2,7 @@
 
 namespace App\Entities\Projects;
 
+use DB;
 use App\Entities\Users\User;
 use Illuminate\Database\Eloquent\Model;
 use Laracasts\Presenter\PresentableTrait;
@@ -112,7 +113,10 @@ class Job extends Model
 
     public function delete()
     {
+        DB::beginTransaction();
         $this->tasks()->delete();
+        $this->comments()->delete();
+        DB::commit();
 
         return parent::delete();
     }

--- a/app/Entities/Projects/Job.php
+++ b/app/Entities/Projects/Job.php
@@ -111,6 +111,11 @@ class Job extends Model
         return $this->price * ($this->progress / 100);
     }
 
+    /**
+     * Delete the model from the database.
+     *
+     * @return bool|null
+     */
     public function delete()
     {
         DB::beginTransaction();

--- a/app/Entities/Projects/Job.php
+++ b/app/Entities/Projects/Job.php
@@ -109,4 +109,11 @@ class Job extends Model
     {
         return $this->price * ($this->progress / 100);
     }
+
+    public function delete()
+    {
+        $this->tasks()->delete();
+
+        return parent::delete();
+    }
 }

--- a/app/Entities/Projects/Project.php
+++ b/app/Entities/Projects/Project.php
@@ -244,4 +244,11 @@ class Project extends Model
 
         return $workDuration.' Day(s)';
     }
+
+    public function delete()
+    {
+        $this->invoices()->delete();
+
+        return parent::delete();
+    }
 }

--- a/app/Entities/Projects/Project.php
+++ b/app/Entities/Projects/Project.php
@@ -253,6 +253,7 @@ class Project extends Model
         $this->invoices()->delete();
         $this->payments()->delete();
         $this->subscriptions()->delete();
+        $this->comments()->delete();
         DB::commit();
 
         return parent::delete();

--- a/app/Entities/Projects/Project.php
+++ b/app/Entities/Projects/Project.php
@@ -252,6 +252,7 @@ class Project extends Model
         $this->jobs->each->delete();
         $this->invoices()->delete();
         $this->payments()->delete();
+        $this->subscriptions()->delete();
         DB::commit();
 
         return parent::delete();

--- a/app/Entities/Projects/Project.php
+++ b/app/Entities/Projects/Project.php
@@ -2,6 +2,7 @@
 
 namespace App\Entities\Projects;
 
+use DB;
 use App\Entities\Invoices\Invoice;
 use App\Entities\Payments\Payment;
 use App\Entities\Partners\Customer;
@@ -247,9 +248,11 @@ class Project extends Model
 
     public function delete()
     {
+        DB::beginTransaction();
         $this->jobs->each->delete();
         $this->invoices()->delete();
         $this->payments()->delete();
+        DB::commit();
 
         return parent::delete();
     }

--- a/app/Entities/Projects/Project.php
+++ b/app/Entities/Projects/Project.php
@@ -246,6 +246,11 @@ class Project extends Model
         return $workDuration.' Day(s)';
     }
 
+    /**
+     * Delete the model from the database.
+     *
+     * @return bool|null
+     */
     public function delete()
     {
         DB::beginTransaction();

--- a/app/Entities/Projects/Project.php
+++ b/app/Entities/Projects/Project.php
@@ -247,7 +247,9 @@ class Project extends Model
 
     public function delete()
     {
+        $this->jobs->each->delete();
         $this->invoices()->delete();
+        $this->payments()->delete();
 
         return parent::delete();
     }

--- a/resources/views/projects/jobs/add-from-other-project.blade.php
+++ b/resources/views/projects/jobs/add-from-other-project.blade.php
@@ -32,7 +32,7 @@
                             @foreach($job->tasks as $task)
                             <li>
                                 <label for="{{ $job->id }}_task_id_{{ $task->id }}" style="font-weight:normal">
-                                {{ Form::checkbox($job->id.'_task_ids['.$task->id.']', $task->id, null, ['id' => $job->id.'_task_id_'.$task->id]) }}
+                                {{ Form::checkbox($job->id.'_task_ids['.$task->id.']', $task->id, null, ['id' => $job->id.'_task_id_'.$task->id, 'class' => 'job_id_'.$job->id.'_tasks']) }}
                                 {{ $task->name }}</label>
                             </li>
                             @endforeach
@@ -72,6 +72,14 @@
 <script>
 (function() {
     $('select[name=project_id]').select2();
+
+    @if ($selectedProject)
+        @foreach ($selectedProject->jobs as $job)
+            $('#job_id_{{ $job->id }}').change(function () {
+                $('.job_id_{{ $job->id }}_tasks').prop('checked', this.checked);
+            });
+        @endforeach
+    @endif
 })();
 </script>
 @endsection

--- a/tests/Unit/Models/JobTest.php
+++ b/tests/Unit/Models/JobTest.php
@@ -55,6 +55,19 @@ class JobTest extends TestCase
     }
 
     /** @test */
+    public function job_deletion_also_deletes_related_tasks()
+    {
+        $job = factory(Job::class)->create();
+        $tasks = factory(Task::class)->create(['job_id' => $job->id]);
+
+        $job->delete();
+
+        $this->dontSeeInDatabase('tasks', [
+            'job_id' => $job->id,
+        ]);
+    }
+
+    /** @test */
     public function a_job_has_progress_attribute()
     {
         $job = factory(Job::class)->create();

--- a/tests/Unit/Models/JobTest.php
+++ b/tests/Unit/Models/JobTest.php
@@ -58,7 +58,7 @@ class JobTest extends TestCase
     public function job_deletion_also_deletes_related_tasks()
     {
         $job = factory(Job::class)->create();
-        $tasks = factory(Task::class)->create(['job_id' => $job->id]);
+        $task = factory(Task::class)->create(['job_id' => $job->id]);
 
         $job->delete();
 
@@ -109,5 +109,22 @@ class JobTest extends TestCase
 
         $this->assertInstanceOf(Collection::class, $job->comments);
         $this->assertInstanceOf(Comment::class, $job->comments->first());
+    }
+
+    /** @test */
+    public function job_deletion_also_deletes_related_comments()
+    {
+        $job = factory(Job::class)->create();
+        $comment = factory(Comment::class)->create([
+            'commentable_type' => 'jobs',
+            'commentable_id'   => $job->id,
+        ]);
+
+        $job->delete();
+
+        $this->dontSeeInDatabase('comments', [
+            'commentable_type' => 'jobs',
+            'commentable_id'   => $job->id,
+        ]);
     }
 }

--- a/tests/Unit/Models/ProjectTest.php
+++ b/tests/Unit/Models/ProjectTest.php
@@ -42,6 +42,19 @@ class ProjectTest extends TestCase
     }
 
     /** @test */
+    public function project_deletion_also_deletes_related_jobs()
+    {
+        $project = factory(Project::class)->create();
+        $job = factory(Job::class)->create(['project_id' => $project->id]);
+
+        $project->delete();
+
+        $this->dontSeeInDatabase('jobs', [
+            'project_id' => $project->id,
+        ]);
+    }
+
+    /** @test */
     public function a_project_has_many_main_jobs()
     {
         $project = factory(Project::class)->create();
@@ -70,12 +83,40 @@ class ProjectTest extends TestCase
     }
 
     /** @test */
-    public function a_project_has_many_payments()
+    public function project_deletion_also_deletes_related_job_tasks()
+    {
+        $project = factory(Project::class)->create();
+        $job = factory(Job::class)->create(['project_id' => $project->id, 'type_id' => 2]);
+        $tasks = factory(Task::class, 2)->create(['job_id' => $job->id]);
+
+        $project->delete();
+
+        $this->dontSeeInDatabase('tasks', [
+            'job_id' => $job->id,
+        ]);
+    }
+
+    /** @test */
+    public function a_project_has_many_payments_relation()
     {
         $project = factory(Project::class)->create();
         $payment = factory(Payment::class)->create(['project_id' => $project->id]);
+
         $this->assertInstanceOf(Collection::class, $project->payments);
         $this->assertInstanceOf(Payment::class, $project->payments->first());
+    }
+
+    /** @test */
+    public function project_deletion_also_deletes_related_payments()
+    {
+        $project = factory(Project::class)->create();
+        $payment = factory(Payment::class)->create(['project_id' => $project->id]);
+
+        $project->delete();
+
+        $this->dontSeeInDatabase('payments', [
+            'project_id' => $project->id,
+        ]);
     }
 
     /** @test */

--- a/tests/Unit/Models/ProjectTest.php
+++ b/tests/Unit/Models/ProjectTest.php
@@ -129,6 +129,19 @@ class ProjectTest extends TestCase
     }
 
     /** @test */
+    public function project_deletion_also_deletes_related_subscriptions()
+    {
+        $project = factory(Project::class)->create();
+        $subscription = factory(Subscription::class)->create(['project_id' => $project->id]);
+
+        $project->delete();
+
+        $this->dontSeeInDatabase('subscriptions', [
+            'project_id' => $project->id,
+        ]);
+    }
+
+    /** @test */
     public function a_project_belongs_to_a_customer()
     {
         $customer = factory(Customer::class)->create();

--- a/tests/Unit/Models/ProjectTest.php
+++ b/tests/Unit/Models/ProjectTest.php
@@ -269,6 +269,23 @@ class ProjectTest extends TestCase
     }
 
     /** @test */
+    public function project_deletion_also_deletes_related_comments()
+    {
+        $project = factory(Project::class)->create();
+        $comment = factory(Comment::class)->create([
+            'commentable_type' => 'projects',
+            'commentable_id'   => $project->id,
+        ]);
+
+        $project->delete();
+
+        $this->dontSeeInDatabase('comments', [
+            'commentable_type' => 'projects',
+            'commentable_id'   => $project->id,
+        ]);
+    }
+
+    /** @test */
     public function project_has_work_duration_attribute()
     {
         $project = factory(Project::class)->create([

--- a/tests/Unit/Models/ProjectTest.php
+++ b/tests/Unit/Models/ProjectTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Models;
 use Tests\TestCase;
 use App\Entities\Projects\Job;
 use App\Entities\Projects\Task;
+use App\Entities\Invoices\Invoice;
 use App\Entities\Payments\Payment;
 use App\Entities\Projects\Comment;
 use App\Entities\Projects\Project;
@@ -233,5 +234,28 @@ class ProjectTest extends TestCase
         ]);
 
         $this->assertEquals('2 Year(s) 3 Month(s)', $project->work_duration);
+    }
+
+    /** @test */
+    public function a_project_has_many_invoices_relation()
+    {
+        $project = factory(Project::class)->create();
+        $invoice = factory(Invoice::class)->create(['project_id' => $project->id]);
+
+        $this->assertInstanceOf(Collection::class, $project->invoices);
+        $this->assertInstanceOf(Invoice::class, $project->invoices->first());
+    }
+
+    /** @test */
+    public function project_deletion_also_deletes_related_invoices()
+    {
+        $project = factory(Project::class)->create();
+        $invoice = factory(Invoice::class)->create(['project_id' => $project->id]);
+
+        $project->delete();
+
+        $this->dontSeeInDatabase('invoices', [
+            'project_id' => $project->id,
+        ]);
     }
 }


### PR DESCRIPTION
On current condition, if we deletes a project. The related records like invoices, payments, jobs are not deleted. In this PR, we have add project related records deletion:

* Jobs deletion
* Job tasks deletion
* Invoices deletion
* Payments deletion
* Subscriptions deletion
* Comments deletion