### PR TITLE
Fix type mismatch by casting variable to (int)

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -26,7 +26,7 @@ function format_money($number)
     }
 
     if ($number < 0) {
-        return '- '.$moneySign.' '.format_no(abs($number));
+        return '- '.$moneySign.' '.format_no(abs((int) $number));
     }
 
     return $moneySign.' '.format_no($number);


### PR DESCRIPTION
Sedikit perbaikan untuk kasus ketika Job price di set 0 menimbulkan error pada tab Activities