### PR TITLE
fix: add missing auth middleware for issue options and comments routes

### DIFF
--- a/routes/web/projects.php
+++ b/routes/web/projects.php
@@ -105,16 +105,16 @@ Route::group(['middleware' => ['auth']], function () {
     Route::post('jobs/{job}/comments', 'Jobs\CommentsController@store')->name('jobs.comments.store');
     Route::patch('jobs/{job}/comments/{comment}', 'Jobs\CommentsController@update')->name('jobs.comments.update');
     Route::delete('jobs/{job}/comments/{comment}', 'Jobs\CommentsController@destroy')->name('jobs.comments.destroy');
+
+    /*
+     * Issue Options Routes
+     */
+    Route::patch('issues/{issue}/options', 'Issues\OptionController@update')->name('issues.options.update');
+
+    /*
+     * Issue Comments Routes
+     */
+    Route::post('issues/{issue}/comments', 'Issues\CommentController@store')->name('issues.comments.store');
+    Route::patch('issues/{issue}/comments/{comment}', 'Issues\CommentController@update')->name('issues.comments.update');
+    Route::delete('issues/{issue}/comments/{comment}', 'Issues\CommentController@destroy')->name('issues.comments.destroy');
 });
-
-/*
- * Issue Options Routes
- */
-Route::patch('issues/{issue}/options', 'Issues\OptionController@update')->name('issues.options.update');
-
-/*
- * Issue Comments Routes
- */
-Route::post('issues/{issue}/comments', 'Issues\CommentController@store')->name('issues.comments.store');
-Route::patch('issues/{issue}/comments/{comment}', 'Issues\CommentController@update')->name('issues.comments.update');
-Route::delete('issues/{issue}/comments/{comment}', 'Issues\CommentController@destroy')->name('issues.comments.destroy');


### PR DESCRIPTION
## Bug

CWE-862 Missing Authorization on 4 issue-related routes.

## Root Cause

Routes were defined outside the `auth` middleware group, allowing unauthenticated requests to modify issue options and comments.

## Fix

Moved all 4 routes inside the existing `Route::group(['middleware' => ['auth']])` block in `routes/web/projects.php`.

## Affected Routes

- `PATCH /issues/{issue}/options` — change priority, status, PIC
- `POST /issues/{issue}/comments` — add comment
- `PATCH /issues/{issue}/comments/{comment}` — edit comment
- `DELETE /issues/{issue}/comments/{comment}` — delete comment

## Reported By

Security researcher via email.